### PR TITLE
Update owner/menus_controller add current_menu?

### DIFF
--- a/app/controllers/owner/menus_controller.rb
+++ b/app/controllers/owner/menus_controller.rb
@@ -1,7 +1,7 @@
 class Owner::MenusController < Owner::Base
 
   before_action :current_restaurant?
-  before_action :current_menu?, except: %i[index new]
+  before_action :current_menu?, except: %i[index new create]
   before_action :api, only: %i[edit new create update]
 
   def index


### PR DESCRIPTION
メニューが作成できないバグを修正しました。

owner/menus_controller.rb
beffor_action current_menu? except: %i[... create]追加